### PR TITLE
namespoofの改善

### DIFF
--- a/scripts/modules/index.js
+++ b/scripts/modules/index.js
@@ -92,6 +92,12 @@ export function namespoof(player) {
   if (!config.namespoof.state) return;
   if (player.name.length > config.namespoof.maxLength) // 長い名前対策
     Util.flag(player, 'Namespoof', config.namespoof.punishment, `長すぎる名前を検知しました`);
+  
+  // 許可された文字のチェック（英数字と空白のみ許可）
+  const allowedRegex = /^[a-zA-Z0-9 ]+$/;
+  if (!allowedRegex.test(player.name)) { // player.nameTagが推奨？
+    Util.flag(player, 'Namespoof', config.namespoof.punishment, '許可されていない文字を含む名前を検知しました');
+  }
 }
 
 /** @param {Player} player */


### PR DESCRIPTION
多分イルカ鯖かどこかで見たことがあるかも、お久しぶりです
身内でnamespoofについての話題が上がってて、tn-acで対策されていないものがあるので提案

namespoofはunicodeを入れることが可能みたい。謎のunicodeに対してマイクラは弱すぎて、すぐフリーズしてしまう傾向にあるので、何かしら対策はしないといけない
コード見る限り文字数制限はしてあるみたいですが、unicodeの方は特に手を付けてないっぽいのでPR送った次第です

a~z, A~Z, 半角空白をホワイトリストとして、それ以外の文字を検知して、上と同じように通知？するだけのものです

コードは実装例です。scriptAPIは触ったことも動かしたこともないのでコードはこれで合ってるかはわかりませんが、ご参考までに

応援してます。